### PR TITLE
Ant.ToString() now returns the pattern used to build the instance

### DIFF
--- a/AntPathMatching.Tests/AntPathMatching.Tests.csproj
+++ b/AntPathMatching.Tests/AntPathMatching.Tests.csproj
@@ -37,11 +37,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AntDirectoryTests.cs" />

--- a/AntPathMatching.Tests/AntTests.cs
+++ b/AntPathMatching.Tests/AntTests.cs
@@ -48,6 +48,7 @@ namespace AntPathMatching
             var ant = new Ant(pattern);
             var match = ant.IsMatch(scenario);
 
+            Assert.That(ant.ToString(), Is.EqualTo(pattern));
             Assert.That(match, Is.EqualTo(expected));
         }
 
@@ -78,6 +79,7 @@ namespace AntPathMatching
             var matcher = new Ant(pattern);
             var result = matcher.IsMatch(input);
 
+            Assert.That(matcher.ToString(), Is.EqualTo(pattern));
             Assert.That(result, Is.EqualTo(shouldMatch));
         }
     }

--- a/AntPathMatching.Tests/AntTests.cs
+++ b/AntPathMatching.Tests/AntTests.cs
@@ -6,6 +6,13 @@ namespace AntPathMatching
     [TestFixture]
     public class AntTests
     {
+        [Test]
+        public void NullInput_ThrowsNothing()
+        {
+            var ant = new Ant("*");
+            Assert.That(() => ant.IsMatch(null), Throws.Nothing);
+        }
+
         [TestCase("/dir1/**/*.txt", "/dir1/dir2/dir3/file1.zip", false)]
         [TestCase("/dir1/**/*.txt", "/dir1/dir2/dir3/file1.txt", true)]
         [TestCase("/dir1/**/*.txt", "/dir1/dir2/dir3/file1.zip", false)]

--- a/AntPathMatching/Ant.cs
+++ b/AntPathMatching/Ant.cs
@@ -6,9 +6,11 @@ namespace AntPathMatching
     /// <summary>
     /// Represents a class which matches paths using ant-style path matching.
     /// </summary>
+    /// <seealso cref="AntPathMatching.IAnt" />
     [DebuggerDisplay("Pattern = {regex}")]
     public class Ant : IAnt
     {
+        private readonly string originalPattern;
         private readonly Regex regex;
 
         /// <summary>
@@ -17,8 +19,9 @@ namespace AntPathMatching
         /// <param name="pattern">Ant-style pattern.</param>
         public Ant(string pattern)
         {
+            originalPattern = pattern ?? string.Empty;
             regex = new Regex(
-                EscapeAndReplace(pattern ?? string.Empty),
+                EscapeAndReplace(originalPattern),
                 RegexOptions.Singleline
             );
         }
@@ -55,5 +58,13 @@ namespace AntPathMatching
 
         private static string GetUnixPath(string txt) => 
             txt.Replace(@"\", "/").TrimStart('/');
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString() => originalPattern;
     }
 }

--- a/AntPathMatching/Ant.cs
+++ b/AntPathMatching/Ant.cs
@@ -32,7 +32,11 @@ namespace AntPathMatching
         /// <param name="input">Path for which to check if it matches the ant-pattern.</param>
         /// <returns>Whether the input matches the pattern.</returns>
         /// <inheritdoc/>
-        public bool IsMatch(string input) => regex.IsMatch(GetUnixPath(input));
+        public bool IsMatch(string input)
+        {
+            input = input ?? string.Empty;
+            return regex.IsMatch(GetUnixPath(input));
+        }
 
         private static string EscapeAndReplace(string pattern)
         {
@@ -56,8 +60,7 @@ namespace AntPathMatching
             return $"^{pattern}$";
         }
 
-        private static string GetUnixPath(string txt) => 
-            txt.Replace(@"\", "/").TrimStart('/');
+        private static string GetUnixPath(string txt) => txt.Replace(@"\", "/").TrimStart('/');
 
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.

--- a/AntPathMatching/AntPathMatching.csproj
+++ b/AntPathMatching/AntPathMatching.csproj
@@ -34,12 +34,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Ant.cs" />


### PR DESCRIPTION
First off, thank you for the library, really helpful.

I've changed the Ant class's `ToString()` method to return the original pattern (prior to replacements). The reason for this is that it facilitates when logging and provides better visibility when a debugger is not being used.

I've added an `Assert` in the existing tests to assert the correct string is being returned.